### PR TITLE
Fixxed RP not saving OnServerSave

### DIFF
--- a/ServerRewards.cs
+++ b/ServerRewards.cs
@@ -1431,6 +1431,11 @@ namespace Oxide.Plugins
         }
         private void SaveLoop() => saveTimer = timer.Once(configData.Options.SaveInterval, () => { SaveRP(); SaveLoop(); });
 
+        private void onServerSave()
+        {
+        	SaveRP();
+        }
+
         private void SendMSG(BasePlayer player, string msg, string keyword = "title")
         {
             if (keyword == "title") keyword = lang.GetMessage("title", this, player.UserIDString);


### PR DESCRIPTION
Could be abused if server would shutdown unexpectedly the RP wouldn't be saved.
This was a problem on our server especially since the host somehow doesn't save the server before shutting down so there's a crash which is at a known time. This caused people to abuse the RP by buying stuff in the 5 minute gap before a restart.